### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,7 +21,6 @@ class ItemsController < ApplicationController
   #end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,16 +15,18 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+
   end
   #def edit
   #end
 
-  #def show
-  #end
+  def show
+    @item = Item.find(params[:id])
+  end
 
   private
   def item_params
-    params.require(:item).permit(:product_name, :product_condition_id, :item_category_id, :price, :delivary_fee_id, :shipping_area_id, :days_to_ship_id, :item_explanation, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:product_name, :product_condition_id, :item_category_id, :price, :delivery_fee_id, :shipping_area_id, :days_to_ship_id, :item_explanation, :image).merge(user_id: current_user.id)
   end
  def set_item
   @item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:edit, :show]
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
   def index
      @items = Item.all.order("created_at DESC")
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,11 +128,12 @@
       <% @items.each do |item| %>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to @item do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
+          
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -99,7 +99,7 @@
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
     <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% if user_signed_in? && current_user.id == @item.user_id %>
+    <% if user_signed_in? && current_user.id != @item.user_id %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
     <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% if user_signed_in?%>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.product_name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -19,18 +19,21 @@
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.delivery_fee_id %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+  <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% if user_signed_in?%>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
@@ -47,23 +50,23 @@
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.item_category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.product_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_to_ship.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -19,7 +19,7 @@
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= @item.delivery_fee_id %>
+        <%= @item.delivery_fee.name %>
       </span>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -40,13 +40,13 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.id %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
@@ -106,7 +106,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href=“#” class=‘another-item’><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href=“#” class=‘another-item’><%= @item.item_category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end

--- a/db/migrate/20201218070330_create_items.rb
+++ b/db/migrate/20201218070330_create_items.rb
@@ -8,7 +8,6 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :shipping_area_id, null: false
       t.integer :days_to_ship_id, null: false
       t.text :item_explanation, null: false
-      t.integer :status_id, null: false
       t.integer :product_condition_id, null: false
       t.references :user, foreign_key: true
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 2020_12_21_141055) do
     t.integer "shipping_area_id", null: false
     t.integer "days_to_ship_id", null: false
     t.text "item_explanation", null: false
-    t.integer "status_id", null: false
     t.integer "product_condition_id", null: false
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
# what 
商品詳細表示機能
# why
商品詳細表示機能を実装するため
ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないことhttps://gyazo.com/62d445cbdb9eb00c11b21896ed7d36b2
ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
商品出品時に登録した情報が見られるようになっていること
https://gyazo.com/5ebc886b2c242a6556860ac79dbc4e53